### PR TITLE
[LLDP] Fix_2 for LLDP advertisements being sent with wrong information.

### DIFF
--- a/dockers/docker-lldp/lldpd.conf.j2
+++ b/dockers/docker-lldp/lldpd.conf.j2
@@ -10,3 +10,5 @@ configure ports eth0 lldp portidsubtype local {{ mgmt_port_name }}
 configure system ip management pattern {{ ipv4 }}
 {% endif %}
 configure system hostname {{ DEVICE_METADATA['localhost']['hostname'] }}
+{# pause lldpd operations until all interfaces are well configured, resume command will run in lldpmgrd #}
+pause

--- a/dockers/docker-lldp/lldpmgrd
+++ b/dockers/docker-lldp/lldpmgrd
@@ -19,6 +19,9 @@ try:
     import subprocess
     import sys
 
+    import syslog
+    import os.path
+    import time
     from sonic_py_common import daemon_base
     from swsscommon import swsscommon
 except ImportError as err:
@@ -27,6 +30,7 @@ except ImportError as err:
 VERSION = "1.0"
 
 SYSLOG_IDENTIFIER = "lldpmgrd"
+PORT_INIT_TIMEOUT = 300
 
 
 class LldpManager(daemon_base.DaemonBase):
@@ -168,7 +172,10 @@ class LldpManager(daemon_base.DaemonBase):
 
         # Daemon is paused on the configuration file to avoid lldp packets with wrong information
         # until all interfaces are well configured on lldpd
-        start_daemon = False
+        port_init_done = False
+        port_config_done = False
+        resume_lldp_sent = False
+        start_time = time.time()
 
         sel = swsscommon.Select()
 
@@ -207,20 +214,22 @@ class LldpManager(daemon_base.DaemonBase):
                                 self.generate_pending_lldp_config_cmd_for_port(key)
                             else:
                                 self.pending_cmds.pop(key, None)
-                elif (key == "PortInitDone") or (key == "PortConfigDone"):
-                    start_daemon = True
+
+                elif key == "PortInitDone":
+                    port_init_done = True
+                elif key == "PortConfigDone":
+                    port_config_done = True
 
             # Process all pending commands
             self.process_pending_cmds()
 
-            # Start the daemon since all interfaces data updated and configured to the lldpd so no miss leading packets will be sent
-            if start_daemon:
-                cmd = "lldpcli resume"
-                proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                (stdout, stderr) = proc.communicate()
-                if proc.returncode != 0:
-                    log_error("Failed to resume lldpd with command: '{}': {}".format(cmd, stderr))
-
+            # Resume the daemon since all interfaces data updated and configured to the lldpd so no miss leading packets will be sent
+            if port_init_done and port_config_done:
+                port_init_done = port_config_done = False
+                resume_lldpd(self)
+                resume_lldp_sent = True
+            if not resume_lldp_sent:
+                check_timeout(self, start_time)
 
 # ============================= Functions =============================
 
@@ -233,6 +242,18 @@ def main():
 
     lldpmgr.run()
 
+def resume_lldpd(self):
+    cmd = "lldpcli resume"
+    proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    (stdout, stderr) = proc.communicate()
+    if proc.returncode != 0:
+        self.log_error("Failed to resume lldpd with command: '{}': {}".format(cmd, stderr))
+        sys.exit(1)
+
+def check_timeout(self, start_time):
+    if time.time() - start_time > PORT_INIT_TIMEOUT:
+        self.log_error("Port init timeout reached ({} seconds), killing lldpmgrd...".format(PORT_INIT_TIMEOUT))
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/dockers/docker-lldp/lldpmgrd
+++ b/dockers/docker-lldp/lldpmgrd
@@ -166,6 +166,10 @@ class LldpManager(daemon_base.DaemonBase):
         # Set select timeout to 10 seconds
         SELECT_TIMEOUT_MS = 1000 * 10
 
+        # Daemon is paused on the configuration file to avoid lldp packets with wrong information
+        # until all interfaces are well configured on lldpd
+        start_daemon = False
+
         sel = swsscommon.Select()
 
         # Subscribe to PORT table notifications in the Config DB
@@ -203,9 +207,19 @@ class LldpManager(daemon_base.DaemonBase):
                                 self.generate_pending_lldp_config_cmd_for_port(key)
                             else:
                                 self.pending_cmds.pop(key, None)
+                elif (key == "PortInitDone") or (key == "PortConfigDone"):
+                    start_daemon = True
 
             # Process all pending commands
             self.process_pending_cmds()
+
+            # Start the daemon since all interfaces data updated and configured to the lldpd so no miss leading packets will be sent
+            if start_daemon:
+                cmd = "lldpcli resume"
+                proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                (stdout, stderr) = proc.communicate()
+                if proc.returncode != 0:
+                    log_error("Failed to resume lldpd with command: '{}': {}".format(cmd, stderr))
 
 
 # ============================= Functions =============================

--- a/src/sonic-config-engine/tests/sample_output/lldpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/lldpd.conf
@@ -1,3 +1,4 @@
 configure ports eth0 lldp portidsubtype local eth0
 configure system ip management pattern 10.0.0.100
 configure system hostname switch-t0
+pause


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Since lldpd is starting before lldpmgrd, some advertisement packets might sent with default value, mac address as Port ID.
This fix hold the packets from being sent by the lldpd until all interfaces are well configured by the lldpmgrd.

**- How I did it**
* Add 'pause' command when lldpd start to avoid false advertisement information.
* Resume lldp operations after ports init is done on DB and all lldpd interfaces configured with correct data.

**- How to verify it**
Capture LLDP advertisement sent from the switch and observe 'Port ID' field.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
