### PR TITLE
[vmcore] Add additional flags for kdump-tools for vmcore dump

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -318,6 +318,11 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     haveged                 \
     jq
 
+## Configure kdump-tools with additional flags for vmcore dump
+sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c 'cat >> /etc/default/kdump-tools <<"EOF"
+KDUMP_SYSCTL="kernel.panic_on_oops=1 kernel.panic_on_unrecovered_nmi=1 kernel.panic_on_io_nmi=1 kernel.panic_on_stackoverflow=1 kernel.hung_task_panic=1 kernel.softlockup_panic=1 kernel.unknown_nmi_panic=1 vm.panic_on_oom=1"
+EOF'
+
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
 ## Pre-install the fundamental packages for amd64 (x86)
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install      \

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -536,7 +536,7 @@ trap_push "rm $grub_cfg || true"
 [ -r ./platform.conf ] && . ./platform.conf
 
 DEFAULT_GRUB_SERIAL_COMMAND="serial --port=${CONSOLE_PORT} --speed=${CONSOLE_SPEED} --word=8 --parity=no --stop=1"
-DEFAULT_GRUB_CMDLINE_LINUX="console=tty0 console=ttyS${CONSOLE_DEV},${CONSOLE_SPEED}n8 quiet"
+DEFAULT_GRUB_CMDLINE_LINUX="console=tty0 console=ttyS${CONSOLE_DEV},${CONSOLE_SPEED}n8 quiet crashkernel=256M"
 GRUB_SERIAL_COMMAND=${GRUB_SERIAL_COMMAND:-"$DEFAULT_GRUB_SERIAL_COMMAND"}
 GRUB_CMDLINE_LINUX=${GRUB_CMDLINE_LINUX:-"$DEFAULT_GRUB_CMDLINE_LINUX"}
 export GRUB_SERIAL_COMMAND


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Allow vmcore dump in additional situations to have better debugging information.

**- How I did it**
Add additional flags to 'kdump-tools' configuration file.
Configure 'crashkernel=256M' in the grub cmdline.

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
