### PR TITLE
[Mellanox] PSU led platform API fixes

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
@@ -15,8 +15,7 @@ class Led(object):
 class SharedLed(object):
     LED_PRIORITY = {
         Led.STATUS_LED_COLOR_RED: 0,
-        Led.STATUS_LED_COLOR_OFF: 1,
-        Led.STATUS_LED_COLOR_GREEN: 2
+        Led.STATUS_LED_COLOR_GREEN: 1
     }
 
     def __init__(self):
@@ -48,8 +47,13 @@ class ComponentFaultyIndicator(object):
         self._shared_led.add_virtual_leds(self)
 
     def set_status(self, color):
+        current_color = self._color
         self._color = color
-        return self._shared_led.update_status_led()
+        if self._shared_led.update_status_led():
+            return True
+        else:
+            self._color = current_color
+            return False
 
     def get_led_color(self):
         return self._color

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
@@ -1,4 +1,8 @@
 class Led(object):
+    LED_PATH = "/var/run/hw-management/led/"
+    LED_ON = '1'
+    LED_OFF = '0'
+    LED_BLINK = '50'
     STATUS_LED_COLOR_GREEN = 'green'
     STATUS_LED_COLOR_GREEN_BLINK = 'green_blink'
     STATUS_LED_COLOR_RED = 'red'
@@ -11,7 +15,8 @@ class Led(object):
 class SharedLed(object):
     LED_PRIORITY = {
         Led.STATUS_LED_COLOR_RED: 0,
-        Led.STATUS_LED_COLOR_GREEN: 1
+        Led.STATUS_LED_COLOR_OFF: 1,
+        Led.STATUS_LED_COLOR_GREEN: 2
     }
 
     def __init__(self):
@@ -24,9 +29,11 @@ class SharedLed(object):
     def update_status_led(self):
         target_color = Led.STATUS_LED_COLOR_GREEN
         for virtual_led in self._virtual_leds:
-            if SharedLed.LED_PRIORITY[virtual_led.get_led_color()] < SharedLed.LED_PRIORITY[target_color]:
-                target_color = virtual_led.get_led_color()
-
+            try:
+                if SharedLed.LED_PRIORITY[virtual_led.get_led_color()] < SharedLed.LED_PRIORITY[target_color]:
+                    target_color = virtual_led.get_led_color()
+            except KeyError:
+                return False
         self._target_color = target_color
         return True
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -13,6 +13,7 @@ try:
     from sonic_platform_base.psu_base import PsuBase
     from sonic_py_common.logger import Logger
     from sonic_platform.fan import Fan
+    from sonic_platform.led import Led
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
@@ -188,7 +189,7 @@ class Psu(PsuBase):
     def _get_led_capability(self):
         cap_list = None
         try:
-            with open(os.path.join(LED_PATH, self.psu_led_cap_path), 'r') as psu_led_cap:
+            with open(os.path.join(Led.LED_PATH, self.psu_led_cap_path), 'r') as psu_led_cap:
                     caps = psu_led_cap.read()
                     cap_list = caps.split()
         except (ValueError, IOError):
@@ -217,31 +218,31 @@ class Psu(PsuBase):
 
         status = False
         try:
-            if color == self.STATUS_LED_COLOR_GREEN:
-                with open(os.path.join(LED_PATH, self.psu_green_led_path), 'w') as psu_led:
-                    psu_led.write(LED_ON)
+            if color == Led.STATUS_LED_COLOR_GREEN:
+                with open(os.path.join(Led.LED_PATH, self.psu_green_led_path), 'w') as psu_led:
+                    psu_led.write(Led.LED_ON)
                     status = True
-            elif color == self.STATUS_LED_COLOR_RED:
+            elif color == Led.STATUS_LED_COLOR_RED:
                 # Some fan don't support red led but support orange led, in this case we set led to orange
-                if self.STATUS_LED_COLOR_RED in led_cap_list:
-                    led_path = os.path.join(LED_PATH, self.psu_red_led_path)
-                elif self.STATUS_LED_COLOR_ORANGE in led_cap_list:
-                    led_path = os.path.join(LED_PATH, self.psu_orange_led_path)
+                if Led.STATUS_LED_COLOR_RED in led_cap_list:
+                    led_path = os.path.join(Led.LED_PATH, self.psu_red_led_path)
+                elif Led.STATUS_LED_COLOR_ORANGE in led_cap_list:
+                    led_path = os.path.join(Led.LED_PATH, self.psu_orange_led_path)
                 else:
                     return False
                 with open(led_path, 'w') as psu_led:
-                    psu_led.write(LED_ON)
+                    psu_led.write(Led.LED_ON)
                     status = True
-            elif color == self.STATUS_LED_COLOR_OFF:
-                if self.STATUS_LED_COLOR_GREEN in led_cap_list:
-                    with open(os.path.join(LED_PATH, self.psu_green_led_path), 'w') as psu_led:
-                        psu_led.write(str(LED_OFF))
-                if self.STATUS_LED_COLOR_RED in led_cap_list:
-                    with open(os.path.join(LED_PATH, self.psu_red_led_path), 'w') as psu_led:
-                        psu_led.write(str(LED_OFF))
-                if self.STATUS_LED_COLOR_ORANGE in led_cap_list:
-                    with open(os.path.join(LED_PATH, self.psu_orange_led_path), 'w') as psu_led:
-                        psu_led.write(str(LED_OFF))
+            elif color == Led.STATUS_LED_COLOR_OFF:
+                if Led.STATUS_LED_COLOR_GREEN in led_cap_list:
+                    with open(os.path.join(Led.LED_PATH, self.psu_green_led_path), 'w') as psu_led:
+                        psu_led.write(str(Led.LED_OFF))
+                if Led.STATUS_LED_COLOR_RED in led_cap_list:
+                    with open(os.path.join(Led.LED_PATH, self.psu_red_led_path), 'w') as psu_led:
+                        psu_led.write(str(Led.LED_OFF))
+                if Led.STATUS_LED_COLOR_ORANGE in led_cap_list:
+                    with open(os.path.join(Led.LED_PATH, self.psu_orange_led_path), 'w') as psu_led:
+                        psu_led.write(str(Led.LED_OFF))
 
                 status = True
             else:
@@ -261,24 +262,24 @@ class Psu(PsuBase):
         """
         led_cap_list = self._get_led_capability()
         if led_cap_list is None:
-            return self.STATUS_LED_COLOR_OFF
+            return Led.STATUS_LED_COLOR_OFF
 
         try:
-            with open(os.path.join(LED_PATH, self.psu_green_led_path), 'r') as psu_led:
-                if LED_OFF != psu_led.read().rstrip('\n'):
-                    return self.STATUS_LED_COLOR_GREEN
-            if self.STATUS_LED_COLOR_RED in led_cap_list:
-                with open(os.path.join(LED_PATH, self.psu_red_led_path), 'r') as psu_led:
-                    if LED_OFF != psu_led.read().rstrip('\n'):
-                        return self.STATUS_LED_COLOR_RED
-            if self.STATUS_LED_COLOR_ORANGE in led_cap_list:
-                with open(os.path.join(LED_PATH, self.psu_orange_led_path), 'r') as psu_led:
-                    if LED_OFF != psu_led.read().rstrip('\n'):
-                        return self.STATUS_LED_COLOR_RED
+            with open(os.path.join(Led.LED_PATH, self.psu_green_led_path), 'r') as psu_led:
+                if Led.LED_OFF != psu_led.read().rstrip('\n'):
+                    return Led.STATUS_LED_COLOR_GREEN
+            if Led.STATUS_LED_COLOR_RED in led_cap_list:
+                with open(os.path.join(Led.LED_PATH, self.psu_red_led_path), 'r') as psu_led:
+                    if Led.LED_OFF != psu_led.read().rstrip('\n'):
+                        return Led.STATUS_LED_COLOR_RED
+            if Led.STATUS_LED_COLOR_ORANGE in led_cap_list:
+                with open(os.path.join(Led.LED_PATH, self.psu_orange_led_path), 'r') as psu_led:
+                    if Led.LED_OFF != psu_led.read().rstrip('\n'):
+                        return Led.STATUS_LED_COLOR_RED
         except (ValueError, IOError) as e:
             raise RuntimeError("Failed to read led status for psu due to {}".format(repr(e)))
 
-        return self.STATUS_LED_COLOR_OFF
+        return Led.STATUS_LED_COLOR_OFF
 
 
     def get_power_available_status(self):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -233,18 +233,6 @@ class Psu(PsuBase):
                 with open(led_path, 'w') as psu_led:
                     psu_led.write(Led.LED_ON)
                     status = True
-            elif color == Led.STATUS_LED_COLOR_OFF:
-                if Led.STATUS_LED_COLOR_GREEN in led_cap_list:
-                    with open(os.path.join(Led.LED_PATH, self.psu_green_led_path), 'w') as psu_led:
-                        psu_led.write(str(Led.LED_OFF))
-                if Led.STATUS_LED_COLOR_RED in led_cap_list:
-                    with open(os.path.join(Led.LED_PATH, self.psu_red_led_path), 'w') as psu_led:
-                        psu_led.write(str(Led.LED_OFF))
-                if Led.STATUS_LED_COLOR_ORANGE in led_cap_list:
-                    with open(os.path.join(Led.LED_PATH, self.psu_orange_led_path), 'w') as psu_led:
-                        psu_led.write(str(Led.LED_OFF))
-
-                status = True
             else:
                 status = False
         except (ValueError, IOError):


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Fix setting PSU led to 'green' or 'red' states.
Fix return False if unsupported color request.
Remove 'off' option for PSU led API since it is not supported in Mellanox.

**- How I did it**
Fix import missing information.
Return 'False' when unsupported led color is requested, preventing an exception.

**- How to verify it**
Try to set PSU LED to different status with Mellanox platform device.
Try to set PSU LED color to unsupported color with Mellanox platform device.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
