### PR TITLE
Change the order of stopping dependent services of SWSS

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -110,14 +110,6 @@ start_peer_and_dependent_services() {
 stop_peer_and_dependent_services() {
     # if warm/fast start enabled or peer lock exists, don't stop peer service docker
     if [[ x"$WARM_BOOT" != x"true" ]] && [[ x"$FAST_BOOT" != x"true" ]]; then
-        if [[ ! -z $DEV ]]; then
-            /bin/systemctl stop ${PEER}@$DEV
-        else
-            /bin/systemctl stop ${PEER}
-        fi
-        for dep in ${DEPENDENT}; do
-            /bin/systemctl stop ${dep}
-        done
         for dep in ${MULTI_INST_DEPENDENT}; do
             if [[ ! -z $DEV ]]; then
                 /bin/systemctl stop ${dep}@$DEV
@@ -125,7 +117,14 @@ stop_peer_and_dependent_services() {
                 /bin/systemctl stop ${dep}
             fi
         done
-
+        for dep in ${DEPENDENT}; do
+            /bin/systemctl stop ${dep}
+        done
+        if [[ ! -z $DEV ]]; then
+            /bin/systemctl stop ${PEER}@$DEV
+        else
+            /bin/systemctl stop ${PEER}
+        fi
     fi
 }
 


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
All SWSS dependent services should stop before SWSS service to avoid future possible issues.
For example 'teamd' service will stop before to allow the driver unload netdev gracefully. 
This is to stop all LAG's before restarting syncd service when running 'config reload' command.

**- How I did it**
Change the order of dependent services of SWSS.

**- How to verify it**
Run 'config reload' command.

**- Previous command output (if the output of a command-line utility has changed)**
The operation failed when a large number of PortChannel configured on the system.
Unloading the LAG's on the driver take a lot of time.
This will make the driver unload all netdev fast and the operation will execute properly

**- New command output (if the output of a command-line utility has changed)**
Success.
