### PR TITLE
[teamd]: Increase wait timeout for teamd docker stop to clean Port channels.

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -352,7 +352,7 @@ wait() {
 }
 
 stop() {
-    docker stop {{docker_container_name}}$DEV
+    docker stop -t 60 {{docker_container_name}}$DEV
 {%- if docker_container_name == "database" %}
     if [ "$DEV" ]; then 
         ip netns delete "$NET_NS"


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Following this PR https://github.com/Azure/sonic-buildimage/pull/6537
Increase wait timeout for teamd docker stop to clean Port channels.
Fixes #6199

**- How I did it**
Changed the container timeout on stop() function for container template.

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
