### PR TITLE
[Mellanox] Add hw-mgmt patch for SimX platform adaptation

### DIFF
--- a/platform/mellanox/hw-management/0003-Make-hw-mgmt-SimX-compatiable.patch
+++ b/platform/mellanox/hw-management/0003-Make-hw-mgmt-SimX-compatiable.patch
@@ -1,0 +1,21 @@
+diff --git a/usr/usr/bin/hw-management-ready.sh b/usr/usr/bin/hw-management-ready.sh
+index 3c9f7b6..22dc090 100755
+--- a/usr/usr/bin/hw-management-ready.sh
++++ b/usr/usr/bin/hw-management-ready.sh
+@@ -49,9 +49,12 @@ if [ -d /var/run/hw-management ]; then
+ 	rm -fr /var/run/hw-management
+ fi
+ 
+-while [ ! -d /sys/devices/platform/mlxplat/mlxreg-hotplug/hwmon ]
+-do
+-	sleep 1
+-done
++if [ "$(cat /sys/devices/virtual/dmi/id/sys_vendor)" != "QEMU" ]; then
++	while [ ! -d /sys/devices/platform/mlxplat/mlxreg-hotplug/hwmon ]
++	do
++		sleep 1
++	done
++fi
++
+ echo "Start Chassis HW management service."
+ logger -t hw-management -p daemon.notice "Start Chassis HW management service."


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
System is stuck on 'starting' state on SimX platform because of infinite loop on 'hw-management-ready.sh' script .
The loop is polling to check if the hw-mgmt sysfs created before proceeding with the flow, for SimX platform the sysfs will never create so the system is not starting properly.

#### How I did it
Add a condition to poll on hw-mgmt sysfs only if the switch is real HW and not SimX platform.

#### How to verify it
Check "systemctl status hw-management.service" output on a SimX switch with this patch, the state will be "active".

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

