### PR TITLE
[dhcp_relay] Disable dhcp_relay for ToRRouter switches type by the feature manager

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -20,7 +20,7 @@
     },
 {%- set features = [("bgp", "enabled", false, "enabled"),
                    ("database", "always_enabled", false, "always_enabled"),
-                   ("dhcp_relay", "enabled", false, "enabled"),
+                   ("dhcp_relay", "disabled", false, "enabled"),
                    ("lldp", "enabled", false, "enabled"),
                    ("pmon", "enabled", false, "enabled"),
                    ("radv", "enabled", false, "enabled"),

--- a/files/image_config/copp/copp_cfg.j2
+++ b/files/image_config/copp/copp_cfg.j2
@@ -79,12 +79,10 @@
 		    "trap_ids": "lldp",
 		    "trap_group": "queue4_group3"
 	    },
-{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] != "ToRRouter") %}
-	    "dhcp": {
+	    "dhcp_relay": {
 		    "trap_ids": "dhcp,dhcpv6",
 		    "trap_group": "queue4_group3"
 	    },
-{% endif %}
 	    "udld": {
 		    "trap_ids": "udld",
 		    "trap_group": "queue4_group3"

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -793,6 +793,12 @@ class HostConfigDaemon:
                 syslog.syslog(syslog.LOG_WARNING, "Enable state of feature '{}' is None".format(feature_name))
                 continue
 
+            # dhcp_relay WA for production issue
+            if feature_name == 'dhcp_relay':
+                device_metadata = self.config_db.get_table('DEVICE_METADATA')
+                if not (device_metadata and device_metadata['localhost'] and device_metadata['localhost']['type'] and device_metadata['localhost']['type'] != "ToRRouter"):
+                    state = "enabled"
+
             target_state = self.get_target_state(feature_name, state)
             # Store the initial value of 'state' field in 'FEATURE' table of a specific container
             self.cached_feature_states[feature_name] = target_state

--- a/src/sonic-host-services/tests/hostcfgd/test_vectors.py
+++ b/src/sonic-host-services/tests/hostcfgd/test_vectors.py
@@ -29,7 +29,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "has_timer": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
-                        "state": "enabled"
+                        "state": "disabled"
                     },
                     "mux": {
                         "auto_restart": "enabled",
@@ -122,7 +122,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "has_timer": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
-                        "state": "enabled"
+                        "state": "disabled"
                     },
                     "mux": {
                         "auto_restart": "enabled",
@@ -154,7 +154,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "has_timer": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
-                        "state": "enabled"
+                        "state": "disabled"
                     },
                     "mux": {
                         "auto_restart": "enabled",
@@ -178,9 +178,6 @@ HOSTCFGD_TEST_VECTOR = [
                 },
             },
             "expected_subprocess_calls": [
-                call("sudo systemctl unmask dhcp_relay.service", shell=True),
-                call("sudo systemctl enable dhcp_relay.service", shell=True),
-                call("sudo systemctl start dhcp_relay.service", shell=True),
                 call("sudo systemctl stop mux.service", shell=True),
                 call("sudo systemctl disable mux.service", shell=True),
                 call("sudo systemctl mask mux.service", shell=True),
@@ -198,6 +195,96 @@ HOSTCFGD_TEST_VECTOR = [
                 "DEVICE_METADATA": {
                     "localhost": {
                         "type": "T1",
+                    }
+                },
+                "KDUMP": {
+                    "config": {
+                        "enabled": "false",
+                        "num_dumps": "3",
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                        }
+                },
+                "FEATURE": {
+                    "dhcp_relay": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "kube",
+                        "state": "disabled"
+                    },
+                    "mux": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "local",
+                        "state": "{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %}enabled{% else %}always_disabled{% endif %}"
+                    },
+                    "telemetry": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "True",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "kube",
+                        "state": "enabled",
+                        "status": "enabled"
+                    },
+                },
+            },
+            "expected_config_db": {
+                "FEATURE": {
+                    "dhcp_relay": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "kube",
+                        "state": "disabled"
+                    },
+                    "mux": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "local",
+                        "state": "always_disabled"
+                    },
+                    "telemetry": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "True",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "kube",
+                        "state": "enabled",
+                        "status": "enabled"
+                    },
+                },
+            },
+            "expected_subprocess_calls": [
+                call("sudo systemctl stop mux.service", shell=True),
+                call("sudo systemctl disable mux.service", shell=True),
+                call("sudo systemctl mask mux.service", shell=True),
+                call("sudo systemctl unmask telemetry.service", shell=True),
+                call("sudo systemctl unmask telemetry.timer", shell=True),
+                call("sudo systemctl enable telemetry.timer", shell=True),
+                call("sudo systemctl start telemetry.timer", shell=True),
+            ],
+        },
+    ],
+    [
+        "SingleToRCase_DHCP_Relay_Enabled",
+        {
+            "config_db": {
+                "DEVICE_METADATA": {
+                    "localhost": {
+                        "type": "ToR",
                     }
                 },
                 "KDUMP": {
@@ -283,5 +370,5 @@ HOSTCFGD_TEST_VECTOR = [
                 call("sudo systemctl start telemetry.timer", shell=True),
             ],
         },
-    ],
+    ]
 ]


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently dhcp packets are disabled by the COPP manager for non ToRRouter type switches.
Even if the feature is enabled, DHCP packets wont hook to the CPU since the COPP manager will not trap this packets.
This change is to disable dhcp_relay by default for non ToRRouter switches from init_cfg.json and hostcfgd.
With this approach, if the user want to enable the feature for non ToRRouter switches, manual enablement is required by the 'feature' configuration.
This is to keep the current approach for MSFT production issue with dhcp relay for non ToRRouter switched and allow the user to decide if to use it or not.

#### How I did it
Configure dhcp_relay 'disabled' by default on init_cfg.json
Remove the exclusion of dhcp packets on copp_cfg.json
Add a condition to enable dhcp_relay for ToRRouter switch on hostcfgd.

#### How to verify it
- Enable dhcp_relay feature on a non ToRRouter switch.
- Unit-tests modified so the default values on mocked CONFIG DB in 'test_vectors.py' for dhcp_relay will be 'disabled'.
This is by the change for 'init_cfg.json.j2'.
For ToRRouter the state will change from 'disabled' to 'enabled'.
Another test case added for a 'ToR' switch type, this is to test the state is 'enabled' if the user configured it to be so.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

