### PR TITLE
[hostcfgd] Delay hostcfgd and aaastatsd for faster boot time

### DIFF
--- a/src/sonic-host-services-data/debian/sonic-host-services-data.aaastatsd.service
+++ b/src/sonic-host-services-data/debian/sonic-host-services-data.aaastatsd.service
@@ -12,6 +12,3 @@ Restart=on-failure
 RestartSec=10
 TimeoutStopSec=3
 
-[Install]
-WantedBy=sonic.target
-

--- a/src/sonic-host-services-data/debian/sonic-host-services-data.aaastatsd.timer
+++ b/src/sonic-host-services-data/debian/sonic-host-services-data.aaastatsd.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Delays aaastatsd daemon until SONiC has started
+PartOf=aaastatsd.service
+
+[Timer]
+OnBootSec=1min 30 sec
+Unit=aaastatsd.service
+
+[Install]
+WantedBy=timers.target sonic.target
+

--- a/src/sonic-host-services-data/debian/sonic-host-services-data.hostcfgd.service
+++ b/src/sonic-host-services-data/debian/sonic-host-services-data.hostcfgd.service
@@ -9,6 +9,3 @@ After=sonic.target
 Type=simple
 ExecStart=/usr/local/bin/hostcfgd
 
-[Install]
-WantedBy=sonic.target
-

--- a/src/sonic-host-services-data/debian/sonic-host-services-data.hostcfgd.timer
+++ b/src/sonic-host-services-data/debian/sonic-host-services-data.hostcfgd.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Delays hostcfgd daemon until SONiC has started
+PartOf=hostcfgd.service
+
+[Timer]
+OnBootSec=1min 30 sec
+Unit=hostcfgd.service
+
+[Install]
+WantedBy=timers.target sonic.target
+


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
hostcfgd is starting at the same time as 'create_switch' method is called on orchagent process.
This introduce a degradation on the function execution time which eventually cause the fast-boot flow and a boot scenarion in general to run slower (~6 seconds).
This change will delay the start time of this daemon.
The aaastatsd will delay as well since it has a dependency on hostcfgd, so it is required to delay both.
90 seconds determined as the maximum allowed downtime for control plane to come back up on fast-boot flow.

#### How I did it
Add two timers for hostcfgd and aaastatsd  services in order to delay the startup of these services.

#### How to verify it
Install an image with this change and observe the daemons start 90 seconds after the system boot.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

