### PR TITLE
[Flex Counters] Reset flex counters delay flag on config DB when enable_counters script is called

### DIFF
--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -18,6 +18,7 @@ def enable_counter_group(db, name):
         info['FLEX_COUNTER_STATUS'] = 'enable'
         db.mod_entry("FLEX_COUNTER_TABLE", name, info)
     else:
+        entry_info.update({"FLEX_COUNTER_DELAY_STATUS":"false"})
         db.mod_entry("FLEX_COUNTER_TABLE", name, entry_info)
 
 def enable_rates():
@@ -49,12 +50,6 @@ def get_uptime():
     with open('/proc/uptime') as fp:
         return float(fp.read().split(' ')[0])
 
-def reset_flex_counters_delay_indicator():
-    db = swsssdk.ConfigDBConnector()
-    db.connect()
-    info = {}
-    info['FLEX_COUNTER_DELAY_STATUS'] = 'false'
-    db.mod_entry("FLEX_COUNTER_TABLE", "FLEX_COUNTER_DELAY", info)
 
 def main():
     # If the switch was just started (uptime less than 5 minutes),
@@ -65,7 +60,6 @@ def main():
         time.sleep(180)
     else:
         time.sleep(60)
-    reset_flex_counters_delay_indicator()
     enable_counters()
 
 

--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -17,6 +17,8 @@ def enable_counter_group(db, name):
         info = {}
         info['FLEX_COUNTER_STATUS'] = 'enable'
         db.mod_entry("FLEX_COUNTER_TABLE", name, info)
+    else:
+        db.mod_entry("FLEX_COUNTER_TABLE", name, entry_info)
 
 def enable_rates():
     # set the default interval for rates
@@ -47,6 +49,12 @@ def get_uptime():
     with open('/proc/uptime') as fp:
         return float(fp.read().split(' ')[0])
 
+def reset_flex_counters_delay_indicator():
+    db = swsssdk.ConfigDBConnector()
+    db.connect()
+    info = {}
+    info['FLEX_COUNTER_DELAY_STATUS'] = 'false'
+    db.mod_entry("FLEX_COUNTER_TABLE", "FLEX_COUNTER_DELAY", info)
 
 def main():
     # If the switch was just started (uptime less than 5 minutes),
@@ -57,6 +65,7 @@ def main():
         time.sleep(180)
     else:
         time.sleep(60)
+    reset_flex_counters_delay_indicator()
     enable_counters()
 
 

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -23,6 +23,13 @@ module sonic-flex_counter {
                 }
             }
 
+            typedef flex_delay_status {
+                type enumeration {
+                    enum true;
+                    enum false;
+                }
+            }
+
             description "FLEX_COUNTER_TABLE part of config_db.json";
 
             /* below are in alphabetical order */
@@ -32,12 +39,18 @@ module sonic-flex_counter {
                 leaf FLEX_COUNTER_STATUS {
                     type flex_status;
                 }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
             }
 
             container DEBUG_COUNTER {
                 /* DEBUG_COUNTER_FLEX_COUNTER_GROUP */
                 leaf FLEX_COUNTER_STATUS {
                     type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
                 }
             }
 
@@ -46,12 +59,18 @@ module sonic-flex_counter {
                 leaf FLEX_COUNTER_STATUS {
                     type flex_status;
                 }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
             }
 
             container PG_DROP {
                 /* PG_DROP_STAT_COUNTER_FLEX_COUNTER_GROUP */
                 leaf FLEX_COUNTER_STATUS {
                     type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
                 }
             }
 
@@ -60,12 +79,18 @@ module sonic-flex_counter {
                 leaf FLEX_COUNTER_STATUS {
                     type flex_status;
                 }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
             }
 
             container PORT {
                 /* PORT_STAT_COUNTER_FLEX_COUNTER_GROUP */
                 leaf FLEX_COUNTER_STATUS {
                     type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
                 }
             }
 
@@ -74,12 +99,18 @@ module sonic-flex_counter {
                 leaf FLEX_COUNTER_STATUS {
                     type flex_status;
                 }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
             }
 
             container PORT_BUFFER_DROP {
                 /* PORT_BUFFER_DROP_COUNTER_FLEX_COUNTER_GROUP */
                 leaf FLEX_COUNTER_STATUS {
                     type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
                 }
             }
 
@@ -88,12 +119,18 @@ module sonic-flex_counter {
                 leaf FLEX_COUNTER_STATUS {
                     type flex_status;
                 }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
             }
 
             container QUEUE_WATERMARK {
                 /* QUEUE_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP */
                 leaf FLEX_COUNTER_STATUS {
                     type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
                 }
             }
 
@@ -102,12 +139,18 @@ module sonic-flex_counter {
                 leaf FLEX_COUNTER_STATUS {
                     type flex_status;
                 }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
             }
 
             container RIF_RATES {
                 /* RIF_RATE_COUNTER_FLEX_COUNTER_GROUP */
                 leaf FLEX_COUNTER_STATUS {
                     type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
                 }
             }
 


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Reset flex counters delay flag on config DB when enable_counters script is called to allow enablement of flex counters in orchagent.

#### How I did it
Push to config DB 'false' value for delay indication when enable_counters script is called before enabling the counters.

#### How to verify it
Observe counters are created when enable_counters script is called.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

