### PR TITLE
[Nvidia] [hw-mgmt] [201911] Add a new patch to set PSU led to green on init by hw-mgmt package

### DIFF
--- a/platform/mellanox/hw-management/0001-set_psu_led_to_green_in_init.patch
+++ b/platform/mellanox/hw-management/0001-set_psu_led_to_green_in_init.patch
@@ -1,0 +1,29 @@
+From 6411e8869adbc969ca0d383b9035cb7a150705c5 Mon Sep 17 00:00:00 2001
+From: Shlomi Bitton <shlomibi@nvidia.com>
+Date: Tue, 24 May 2022 12:07:41 +0000
+Subject: [PATCH] Add a new patch to set PSU led to green on init to resolve
+ race condition issue
+
+Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>
+---
+ usr/usr/bin/hw-management-chassis-events.sh | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/usr/usr/bin/hw-management-chassis-events.sh b/usr/usr/bin/hw-management-chassis-events.sh
+index 2d6c70b..8f6b57d 100755
+--- a/usr/usr/bin/hw-management-chassis-events.sh
++++ b/usr/usr/bin/hw-management-chassis-events.sh
+@@ -514,7 +514,9 @@ if [ "$1" == "add" ]; then
+ 		name=$(echo "$5" | cut -d':' -f2)
+ 		color=$(echo "$5" | cut -d':' -f3)
+ 		ln -sf "$3""$4"/brightness $led_path/led_"$name"_"$color"
+-		echo timer > "$3""$4"/trigger
++                if [ "$color" == "green" ]; then
++                    echo timer > "$3""$4"/trigger
++                fi
+ 		ln -sf "$3""$4"/delay_on  $led_path/led_"$name"_"$color"_delay_on
+ 		ln -sf "$3""$4"/delay_off $led_path/led_"$name"_"$color"_delay_off
+ 		ln -sf $LED_STATE $led_path/led_"$name"_state
+-- 
+2.14.1
+


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

As a result of race condition, PSU led may appear as red.
This fix set the PSU led color to green on init.

#### How I did it

Add a new patch for hw-mgmt package to set led color to green in init.

#### How to verify it

Build SONiC image for Nvidia platform and observe PSU led set to green on init.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

